### PR TITLE
Fix scalelab's disabling of ipv6

### DIFF
--- a/ansible/roles/vm-host-network/tasks/main.yml
+++ b/ansible/roles/vm-host-network/tasks/main.yml
@@ -33,6 +33,13 @@
   - src: resolv.conf.j2
     dest: /etc/resolv.conf
 
+- name: Comment out scale lab injected ipv6 disabling
+  replace:
+    path: /etc/sysctl.conf
+    regexp: "net.ipv6.conf.all.disable_ipv6 = 1"
+    replace: "# net.ipv6.conf.all.disable_ipv6 = 1"
+    backup: true
+
 - name: Set ip_forward sysctl (ipv6)
   sysctl:
     name: "{{ item.name }}"


### PR DESCRIPTION
We should comment this out because if a hypervisor reboots, it won't be
able to communicate over ipv6 until net.ipv6.conf.all.disable_ipv6 = 0
is applied again.